### PR TITLE
Add support for search API

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -7,6 +7,7 @@ import { MusicVideoResponse } from './serverTypes/musicVideoResponse';
 import { PlaylistResponse } from './serverTypes/playlistResponse';
 import { SongResponse } from './serverTypes/songResponse';
 import { StationResponse } from './serverTypes/stationResponse';
+import { SearchResponse } from './serverTypes/searchResponse';
 
 export class Client {
   configuration: ClientConfiguration;
@@ -17,6 +18,7 @@ export class Client {
   playlists: ResourceClient<PlaylistResponse>;
   songs: ResourceClient<SongResponse>;
   stations: ResourceClient<StationResponse>;
+  search: ResourceClient<SearchResponse>;
 
   constructor(configuration: ClientConfiguration) {
     this.configuration = configuration;
@@ -27,5 +29,6 @@ export class Client {
     this.playlists = new ResourceClient<PlaylistResponse>('playlists', this.configuration);
     this.songs = new ResourceClient<SongResponse>('songs', this.configuration);
     this.stations = new ResourceClient<StationResponse>('stations', this.configuration);
+    this.search = new ResourceClient<SearchResponse>('search', this.configuration);
   }
 }

--- a/src/resourceClient.ts
+++ b/src/resourceClient.ts
@@ -9,19 +9,20 @@ import { Error } from './serverTypes/error';
 
 interface Parameters {
   l?: string;
+  term?: string;
 }
 
 export class ResourceClient<T extends ResponseRoot> {
   private axiosInstance: AxiosInstance;
 
-  constructor(public urlName: string, public configuration: ClientConfiguration) {
+  constructor(public resourceName: string, public configuration: ClientConfiguration) {
     this.axiosInstance = axios.create({
       baseURL: 'https://api.music.apple.com/v1',
       headers: {
         Authorization: `Bearer ${this.configuration.developerToken}`
       },
       // https://github.com/axios/axios/blob/v0.20.0-0/lib/defaults.js#L57-L65
-      transformResponse: [(data) => {
+      transformResponse: [(data: any) => {
         /*eslint no-param-reassign:0*/
         if (typeof data === 'string') {
           try {
@@ -34,18 +35,20 @@ export class ResourceClient<T extends ResponseRoot> {
     });
   }
 
-  async get(id: string, options?: { storefront?: string; languageTag?: string }): Promise<T> {
+  async get(query: string, options?: { storefront?: string; languageTag?: string }): Promise<T> {
     const storefront = options?.storefront || this.configuration.defaultStorefront;
 
     if (!storefront) {
       throw new Error(`Specify storefront with function parameter or default one with Client's constructor`);
     }
 
-    const url = `/catalog/${storefront}/${this.urlName}/${id}`;
+    const url = buildRequestUrl(this.resourceName, storefront, query);
 
-    let params: Parameters = {
+    const params: Parameters = {
       l: options?.languageTag || this.configuration.defaultLanguageTag
     };
+
+    if (this.resourceName === 'search') params.term = query;
 
     const httpResponse = await this.request('GET', url, params);
 
@@ -74,6 +77,17 @@ export class ResourceClient<T extends ResponseRoot> {
 }
 
 const datePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+
+function buildRequestUrl(resourceName: string, storefront: string, query: string): string {
+  switch (resourceName) {
+    case 'search': {
+      return `/catalog/${storefront}/search`;
+    }
+    default: {
+      return `/catalog/${storefront}/${resourceName}/${query}`;
+    }
+  }
+}
 
 function parseJSONWithDateHandling(json: string) {
   return JSON.parse(json, (_key: any, value: any) => {

--- a/src/serverTypes/searchResponse.ts
+++ b/src/serverTypes/searchResponse.ts
@@ -1,0 +1,17 @@
+import { AlbumResponse } from './albumResponse';
+import { ArtistResponse } from './artistResponse';
+import { MusicVideoResponse } from './musicVideoResponse';
+import { PlaylistResponse } from './playlistResponse';
+import { ResponseRoot } from './responseRoot';
+import { SongResponse } from './songResponse';
+
+// https://developer.apple.com/documentation/applemusicapi/searchresponse
+export interface SearchResponse extends ResponseRoot {
+  results: {
+    songs: SongResponse;
+    albums: AlbumResponse;
+    playlists: PlaylistResponse;
+    artists: ArtistResponse;
+    'music-videos': MusicVideoResponse;
+  };
+}


### PR DESCRIPTION
@yujinakayama Thanks for the repo. It helped me getting started with Apple Music API with ease 🙂 
I've added support for the [GET https://api.music.apple.com/v1/catalog/{storefront}/search endpoint](https://developer.apple.com/documentation/applemusicapi/search_for_catalog_resources).

Expected use case is as follows:

```ts
const res = await client.search.get('Ed Sheeran', { storefront: 'us' });
```